### PR TITLE
marked Image360Controller as open

### DIFF
--- a/Image360/Core/Image360Controller.swift
+++ b/Image360/Core/Image360Controller.swift
@@ -29,7 +29,7 @@ private let blackFileURL = Bundle(for: Image360Controller.self).url(forResource:
 
 /// ## Image360Controller
 /// This controller presentes a special view to dysplay 360° panoramic image.
-public class Image360Controller: UIViewController {
+open class Image360Controller: UIViewController {
     /// Image 360 view which actually dysplays 360° panoramic image.
     public var imageView: Image360View
     /// Special OpenGL controller to ouput Image360View
@@ -148,7 +148,7 @@ public class Image360Controller: UIViewController {
         
     }
 
-    public override func loadView() {
+    open override func loadView() {
         super.loadView()
         addChildViewController(image360GLController)
         view.addSubview(imageView)
@@ -166,14 +166,14 @@ public class Image360Controller: UIViewController {
     // MARK: Appear/Disappear
     private var isAppear = false
 
-    public override func viewWillAppear(_ animated: Bool) {
+    open override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         if let presentedImage = imageView.image {
             imageView.image = presentedImage
         }
     }
 
-    public override func viewDidAppear(_ animated: Bool) {
+    open override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         if isDeviceMotionControlEnabled {
             enableDeviceMotionControl()
@@ -181,7 +181,7 @@ public class Image360Controller: UIViewController {
         isAppear = true
     }
 
-    public override func viewDidDisappear(_ animated: Bool) {
+    open override func viewDidDisappear(_ animated: Bool) {
         imageView.unloadTextures()
 
         super.viewDidDisappear(animated)


### PR DESCRIPTION
As of Swift 3 files need to be marked as `open` to allow access to files outside the module. This is important when using this code as a pod rather than just dropping the files in. 

Love the work you've done and I plan to build something cool with it :)